### PR TITLE
feat: allow disabling prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The most specific folder path will take precedence.
 This means, if you assign a template for the root folder ("/"), all the new files will automatically apply that template.
 Still, you can assign other templates for folders to overwrite that behavior.
 
+If you _only_ want to use folder-specific templates and do not want to be prompted to pick a template, use the `Disable prompt` option.
+
 ## Prerequisites
 
 It depends on the core `Templates` plugin to be enabled, and that a a templates folder is assigned.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "auto-template-trigger",
-			"version": "1.2.1",
+			"version": "1.2.2",
 			"license": "MIT",
 			"dependencies": {
 				"@popperjs/core": "^2.11.8"

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,7 +107,7 @@ export default class AutoTemplatePromptPlugin extends Plugin {
 				this.applySpecificTemplate(assignedTemplate);
 			}
 
-			if (!assignedTemplate) {
+			if (!assignedTemplate && !this.settings.disablePrompt) {
 				this.triggerTemplateSelectorPrompt();
 			}
 		}

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -5,10 +5,12 @@ import { getTemplatesFolder } from "utils/utils";
 
 export interface PluginSettings {
 	folderSpecificTemplates: { folderPath: string; templateName: string }[];
+	disablePrompt: boolean;
 }
 
 export const DEFAULT_SETTINGS: PluginSettings = {
 	folderSpecificTemplates: [],
+	disablePrompt: false,
 };
 
 export class Settings extends PluginSettingTab {
@@ -106,5 +108,19 @@ export class Settings extends PluginSettingTab {
 				this.display();
 			});
 		});
+
+		new Setting(containerEl)
+			.setName("Disable prompt")
+			.setDesc(
+				"Do not prompt for a template when there is no folder-specific template match."
+			)
+			.addToggle((cb) => {
+				cb.setValue(this.plugin.settings.disablePrompt).onChange(
+					async (value) => {
+						this.plugin.settings.disablePrompt = value;
+						await this.plugin.saveSettings();
+					}
+				);
+			});
 	}
 }


### PR DESCRIPTION
Closes #20.

First: thanks for the plugin! The folder-specific template functionality is something I've always wanted but never got around to putting together. 

As in the linked issue, I only use templates for certain types of notes, so ideally, I'd like to _only_ use folder-specific templates and not be prompted otherwise. This PR adds a setting to do just that. (This is technically already possible by configuring a blank folder-specific template for the vault root and putting it last, but it's a bit of a hack.)

